### PR TITLE
Make annotation notes searchable

### DIFF
--- a/processors/compression/compression.js
+++ b/processors/compression/compression.js
@@ -88,7 +88,10 @@ async function process(pageData, options) {
 		if (options.insertTextBody) {
 			const doc = (new DOMParser()).parseFromString(pageData.content, "text/html");
 			doc.body.querySelectorAll("style, script, noscript").forEach(element => element.remove());
-			pageContent += "\n<main hidden>\n" + doc.body.innerText.replace(/</g, "&lt;").replace(/>/g, "&gt;").trim() + "\n</main>\n";
+			textBody = doc.body.innerText;
+			doc.body.querySelectorAll("single-file-note").forEach(node => textBody += "\n" + node.shadowRoot.querySelector("textarea").value);
+			textBody = textBody.replace(/</g, "&lt;").replace(/>/g, "&gt;").trim();
+			pageContent += "\n<main hidden>\n" + textBody + "\n</main>\n";
 		}
 		pageContent += "</body><xmp><![CDATA[";
 		await writeData(blobWriter.writable, (new TextEncoder()).encode(pageContent));


### PR DESCRIPTION
Annotation notes use shadow DOM and its contents are not visible when using `innerText`. To make the notes searchable, we manually take their contents from the shadow DOM and include them in the uncompressed text.

*Note: I haven't tested this yet. Would like to get confirmation that including the notes is something that you'd approve in the first place before spending more time on this :).*